### PR TITLE
Fechando tag <a> em template.

### DIFF
--- a/telemob/main/templates/contact_add.html
+++ b/telemob/main/templates/contact_add.html
@@ -34,7 +34,7 @@
     </tr>
     <tr>
         <th>Telegrama</th>
-        <td>Você envia online e o carteiro entrega em mãos. Custa R$ 4,98 e pode ser enviado pelo site dos Correios <a target="_blank" href="http://shopping.correios.com.br/wbm/store/script/wbm2400901p01.aspx?cd_company=ErZW8Dm9i54=&cd_product=IFYzQdTZeXo=">(link direto oficial). Veja <a href="#modelo-texto">modelo de texto</a>.</td>
+        <td>Você envia online e o carteiro entrega em mãos. Custa R$ 4,98 e pode ser enviado pelo site dos Correios <a target="_blank" href="http://shopping.correios.com.br/wbm/store/script/wbm2400901p01.aspx?cd_company=ErZW8Dm9i54=&cd_product=IFYzQdTZeXo=">(link direto oficial)</a>. Veja <a href="#modelo-texto">modelo de texto</a>.</td>
     </tr>
     <tr>
         <th>Fax</th>


### PR DESCRIPTION
Ficou faltando fechar a tag <a> na explicação da forma de contato 'telegrama'
